### PR TITLE
fix `ember ts:precompile` by adding `skipLibCheck` to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "baseUrl": ".",
     "module": "es6",
     "experimentalDecorators": true,
+    "skipLibCheck": true, // https://github.com/typed-ember/ember-cli-typescript/issues/1029
     "paths": {
       "dummy/tests/*": [
         "tests/*"


### PR DESCRIPTION
this is a workaround until I hear back about the following issue:
https://github.com/typed-ember/ember-cli-typescript/issues/1029

this was also causing issues with `npm publish` because that command also runs `ember ts:precompile`