### PR TITLE
dependabot changelog committer removal+ dependabot default label removal

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -15,4 +15,3 @@ update_configs:
           dependency_name: "ember-cli"
     default_labels:
       - "dependencies"
-      - "internal"

--- a/package.json
+++ b/package.json
@@ -161,6 +161,9 @@
       "publish": true
     }
   },
+  "changelog": {
+    "ignoreCommitters": ["dependabot"]
+  },
   "volta": {
     "node": "12.20.2",
     "yarn": "1.22.10"


### PR DESCRIPTION
remove "dependabot" from changelog committers + remove dependabot default `internal` label to avoid showing in changelog